### PR TITLE
MultiLocaleValue alternative Locale support 2/2

### DIFF
--- a/src/main/java/walkingkooka/j2cl/java/util/locale/support/MultiLocaleValue.java
+++ b/src/main/java/walkingkooka/j2cl/java/util/locale/support/MultiLocaleValue.java
@@ -47,8 +47,10 @@ public final class MultiLocaleValue<T> implements Predicate<Locale> {
 
     @Override
     public boolean test(final Locale locale) {
+        // Optional.stream() not available in GWT/J2CL
+        final Optional<Locale> alternatives = LocaleSupport.alternatives(locale);
         return this.locales.test(locale) ||
-                LocaleSupport.alternatives(locale).stream().anyMatch(this.locales);
+                alternatives.isPresent() && this.locales.test(alternatives.get());
     }
 
     private final Predicate<Locale> locales;


### PR DESCRIPTION
- Replaced Optional.stream with equivalent because of unavailability in gwt jre.