### PR TITLE
gwt POM: removed walkingkooka:j2cl-java-util-Locale-annotation-processor

### DIFF
--- a/gwt-pom.xml
+++ b/gwt-pom.xml
@@ -90,19 +90,6 @@
             <artifactId>gwt-locale</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-
-        <dependency>
-            <groupId>walkingkooka</groupId>
-            <artifactId>j2cl-java-util-Locale-annotation-processor</artifactId>
-            <version>1.0-SNAPSHOT</version>
-
-            <exclusions>
-                <exclusion>
-                    <groupId>walkingkooka</groupId>
-                    <artifactId>j2cl-locale</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,13 @@
                 <configuration>
                     <source>9</source>
                     <target>9</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>walkingkooka</groupId>
+                            <artifactId>j2cl-java-util-Locale-annotation-processor</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                        </path>
+                    </annotationProcessorPaths>
                     <compilerArgs>
                         <arg>-Awalkingkooka.j2cl.java.util.Locale=*</arg>
                         <arg>-Awalkingkooka.j2cl.java.util.Locale.DEFAULT=en-AU</arg>
@@ -157,6 +164,7 @@
                     <verbose>true</verbose>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/src/it/gwt-jar-test/pom.xml
+++ b/src/it/gwt-jar-test/pom.xml
@@ -69,9 +69,16 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>walkingkooka</groupId>
+                            <artifactId>j2cl-java-util-Locale-annotation-processor</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                        </path>
+                    </annotationProcessorPaths>
                     <compilerArgs>
-                        <arg>-Awalkingkooka.j2cl.java.util.Locale=EN-AU</arg>
-                        <arg>-Awalkingkooka.j2cl.java.util.Locale.DEFAULT=EN-AU</arg>
+                        <arg>-Awalkingkooka.j2cl.java.util.Locale=en-AU</arg>
+                        <arg>-Awalkingkooka.j2cl.java.util.Locale.DEFAULT=en-AU</arg>
                         <arg>-Awalkingkooka.j2cl.locale.Logging=SLASH_SLASH_COMMENTS</arg>
                     </compilerArgs>
                     <showWarnings>true</showWarnings>

--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -38,6 +38,7 @@ import com.google.gwt.junit.client.GWTTestCase;
 import java.util.Locale;
 import walkingkooka.j2cl.locale.LocaleAware;
 
+@LocaleAware
 public class TestGwtTest extends GWTTestCase {
     @Override
     public String getModuleName() {


### PR DESCRIPTION
- walkingkooka:j2cl-java-util-Locale-annotation-processor must be added to maven-compiler-plugin annotationProcesors.